### PR TITLE
Fix github release ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           path: dist/
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,5 +111,5 @@ jobs:
         # Upload to GitHub Release using the `gh` CLI.
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.
-        run: gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'
+        run: gh release upload '${{ needs.tag-release-on-push.outputs.new_tag }}' dist/** --repo '${{ github.repository }}'
     


### PR DESCRIPTION
## Checklist
Please tick off where applicable. Have you:
- [ ] updated the version number in [pyproject.toml](pyproject.toml)?
- [ ] updated the version number in [action.yml](https://github.com/DFE-Digital/splunk-app-packager/blob/composite-deploy-action/action.yml#L41)?
- [x] explained the change?
- [ ] confirmed the PR checks have passed?

## Explanation of change
This is a simple fix to update the reference for uploading artifacts in the github release. Needs to be the version number in the previous step.


